### PR TITLE
Introduce RetryableErrors

### DIFF
--- a/lib/zorki.rb
+++ b/lib/zorki.rb
@@ -18,6 +18,20 @@ module Zorki
     end
   end
 
+  class RetryableError < Error; end
+
+  class ImageRequestTimedOutError < RetryableError
+    def initialize(msg = "Zorki encountered a timeout error requesting an image")
+      super
+    end
+  end
+
+  class ImageRequestFailedError < RetryableError
+    def initialize(msg = "Zorki received a non-200 response requesting an image")
+      super
+    end
+  end
+
   define_setting :temp_storage_location, "tmp/zorki"
 
   # Get an image from a URL and save to a temp folder set in the configuration under

--- a/lib/zorki/scrapers/scraper.rb
+++ b/lib/zorki/scrapers/scraper.rb
@@ -47,6 +47,8 @@ module Zorki
   private
 
     def login
+      raise Zorki::Error
+
       # Go to the home page
       visit("/")
       # Check if we're redirected to a login page, if we aren't we're already logged in
@@ -66,9 +68,9 @@ module Zorki
         if request.success?
           return request.body
         elsif request.timed_out?
-          raise Zorki::Error("Fetching image at #{url} timed out")
+          raise Zorki::ImageRequestTimedOutError
         else
-          raise Zorki::Error("Fetching image at #{url} returned non-successful HTTP server response #{request.code}")
+          raise Zorki::ImageRequestFailedError, "Fetching image at #{url} returned non-successful HTTP server response #{request.code}"
         end
       end
     end


### PR DESCRIPTION
This PR changes some exceptions to inherit from `RetryableError`. This enables Hypatia to properly handle them. See https://github.com/TechAndCheck/hypatia/pull/26 