### PR TITLE
standardize media filenames across scrapers; fix missing extensions

### DIFF
--- a/lib/zorki.rb
+++ b/lib/zorki.rb
@@ -47,7 +47,8 @@ module Zorki
     response = Typhoeus.get(url)
 
     # Get the file extension if it's in the file
-    extension = url.split(".").last
+    stripped_url = url.split("?").first  # remove URL query params
+    extension = stripped_url.split(".").last
 
     # Do some basic checks so we just empty out if there's something weird in the file extension
     # that could do some harm.
@@ -56,7 +57,7 @@ module Zorki
       extension = ".#{extension}" unless extension.nil?
     end
 
-    temp_file_name = "#{Zorki.temp_storage_location}/#{SecureRandom.uuid}#{extension}"
+    temp_file_name = "#{Zorki.temp_storage_location}/instagram_media_#{SecureRandom.uuid}#{extension}"
 
     # We do this in case the folder isn't created yet, since it's a temp folder we'll just do so
     self.create_temp_storage_location

--- a/lib/zorki/scrapers/post_scraper.rb
+++ b/lib/zorki/scrapers/post_scraper.rb
@@ -78,7 +78,7 @@ module Zorki
       end
 
       # Take the screenshot and return it
-      save_screenshot("#{Zorki.temp_storage_location}/#{SecureRandom.uuid}_screenshot.png")
+      save_screenshot("#{Zorki.temp_storage_location}/instagram_screenshot_#{SecureRandom.uuid}.png")
     end
   end
 end


### PR DESCRIPTION
This PR, along with https://github.com/TechAndCheck/hypatia/pull/46, https://github.com/TechAndCheck/forki/pull/20, and https://github.com/TechAndCheck/YoutubeArchiver/pull/7, standardizes media filenames across scrapers. It also fixes a bug in which extensions weren't being properly added to filenames. 

# Testing instructions
`rake test`